### PR TITLE
Continuous self play

### DIFF
--- a/cpp/core/AbstractPlayerGenerator.hpp
+++ b/cpp/core/AbstractPlayerGenerator.hpp
@@ -4,11 +4,10 @@
 #include <string>
 #include <vector>
 
-#include <boost/program_options.hpp>
-
 #include <core/AbstractPlayer.hpp>
 #include <core/BasicTypes.hpp>
 #include <core/GameStateConcept.hpp>
+#include <util/BoostUtil.hpp>
 
 namespace core {
 
@@ -125,10 +124,8 @@ class AbstractPlayerGenerator {
    */
   template <typename T>
   void parse_args_helper(T&& desc, const std::vector<std::string>& args) {
-    namespace po = boost::program_options;
-    po::variables_map vm;
-    po::store(po::command_line_parser(args).options(desc).run(), vm);
-    po::notify(vm);
+    namespace po2 = boost_util::program_options;
+    po2::parse_args(desc, args);
   }
 
  private:

--- a/cpp/core/Main.hpp
+++ b/cpp/core/Main.hpp
@@ -52,17 +52,20 @@ struct Main {
 
       po2::options_description raw_desc("General options");
       auto desc = raw_desc.template add_option<"help", 'h'>("help")
+                      .template add_option<"help-full">("help with no-op flags included")
                       .add(args.make_options_description())
                       .add(game_server_params.make_options_description())
                       .add(game_server_proxy_params.make_options_description());
 
-      po::variables_map vm;
-      po::store(po::command_line_parser(ac, av).options(desc).run(), vm);
-      po::notify(vm);
+      po::variables_map vm = po2::parse_args(desc, ac, av);
 
       PlayerFactory player_factory;
-      if (vm.count("help")) {
-        std::cout << desc << std::endl;
+      bool help_full = vm.count("help-full");
+      bool help = vm.count("help");
+      if (help || help_full) {
+        po2::Settings::help_full = help_full;
+        desc.print(std::cout);
+        std::cout << std::endl;
         player_factory.print_help(args.player_strs);
         return 0;
       }

--- a/cpp/core/Main.hpp
+++ b/cpp/core/Main.hpp
@@ -64,8 +64,7 @@ struct Main {
       bool help = vm.count("help");
       if (help || help_full) {
         po2::Settings::help_full = help_full;
-        desc.print(std::cout);
-        std::cout << std::endl;
+        std::cout << desc << std::endl;
         player_factory.print_help(args.player_strs);
         return 0;
       }

--- a/cpp/core/inl/GameServer.inl
+++ b/cpp/core/inl/GameServer.inl
@@ -43,13 +43,13 @@ auto GameServer<GameState>::Params::make_options_description() {
           po::value<int>(&parallelism)->default_value(parallelism),
           "max num games to play simultaneously. Participating players can request lower values "
           "and the server will respect their requests")
-      .template add_bool_switches<"display-progress-bar", "hide-progress-bar">(
+      .template add_flag<"display-progress-bar", "hide-progress-bar">(
           &display_progress_bar, "display progress bar (only in tty-mode without TUI player)",
           "hide progress bar")
-      .template add_bool_switches<"announce-game-results", "do-not-announce-game-results">(
+      .template add_flag<"announce-game-results", "do-not-announce-game-results">(
           &announce_game_results, "announce result after each individual game",
           "do not announce result after each individual game")
-      .template add_bool_switches<"respect-victory-hints", "do-not-respect-victory-hints">(
+      .template add_flag<"respect-victory-hints", "do-not-respect-victory-hints">(
           &respect_victory_hints, "immediately exit game if a player claims imminent victory",
           "ignore imminent victory claims from players");
 }

--- a/cpp/core/inl/PlayerFactory.inl
+++ b/cpp/core/inl/PlayerFactory.inl
@@ -77,7 +77,7 @@ typename PlayerFactory<GameState>::player_generator_seat_vec_t PlayerFactory<Gam
 template <GameStateConcept GameState>
 void PlayerFactory<GameState>::print_help(const std::vector<std::string>& player_strs) {
   Params params;
-  params.make_options_description().print(std::cout);
+  std::cout << params.make_options_description();
   std::cout << "  --... ...             type-specific args, dependent on --type" << std::endl
             << std::endl;
 

--- a/cpp/games/connect4/main/GenerateOracleLabeledGames.cpp
+++ b/cpp/games/connect4/main/GenerateOracleLabeledGames.cpp
@@ -163,9 +163,7 @@ int main(int ac, char* av[]) {
                   .add(parallel_game_runner_params.make_options_description())
                   .add(training_data_writer_params.make_options_description());
 
-  po::variables_map vm;
-  po::store(po::command_line_parser(ac, av).options(desc).run(), vm);
-  po::notify(vm);
+  auto vm = po2::parse_args(desc, ac, av);
 
   if (vm.count("help")) {
     std::cout << desc << std::endl;

--- a/cpp/games/connect4/players/inl/PerfectPlayerGenerator.inl
+++ b/cpp/games/connect4/players/inl/PerfectPlayerGenerator.inl
@@ -1,6 +1,6 @@
 #include <games/connect4/players/PerfectPlayerGenerator.hpp>
 
-#include <boost/program_options.hpp>
+#include <util/BoostUtil.hpp>
 
 namespace c4 {
 
@@ -9,10 +9,8 @@ inline std::string PerfectPlayerGenerator::get_default_name() const {
 }
 
 inline void PerfectPlayerGenerator::parse_args(const std::vector<std::string>& args) {
-  namespace po = boost::program_options;
-  po::variables_map vm;
-  po::store(po::command_line_parser(args).options(params_.make_options_description()).run(), vm);
-  po::notify(vm);
+  namespace po2 = boost_util::program_options;
+  po2::parse_args(params_.make_options_description(), args);
 }
 
 }  // namespace c4

--- a/cpp/games/othello/players/EdaxPlayerGenerator.hpp
+++ b/cpp/games/othello/players/EdaxPlayerGenerator.hpp
@@ -3,8 +3,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/program_options.hpp>
-
 #include <core/AbstractPlayer.hpp>
 #include <core/BasicTypes.hpp>
 #include <games/othello/GameState.hpp>
@@ -24,10 +22,8 @@ class EdaxPlayerGenerator : public core::AbstractPlayerGenerator<othello::GameSt
   Player* generate(core::game_thread_id_t) override { return new EdaxPlayer(params_); }
   void print_help(std::ostream& s) override { params_.make_options_description().print(s); }
   void parse_args(const std::vector<std::string>& args) {
-    namespace po = boost::program_options;
-    po::variables_map vm;
-    po::store(po::command_line_parser(args).options(params_.make_options_description()).run(), vm);
-    po::notify(vm);
+    namespace po2 = boost_util::program_options;
+    po2::parse_args(params_.make_options_description(), args);
   }
 
  private:

--- a/cpp/games/tictactoe/players/PerfectPlayerGenerator.hpp
+++ b/cpp/games/tictactoe/players/PerfectPlayerGenerator.hpp
@@ -3,8 +3,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/program_options.hpp>
-
 #include <core/AbstractPlayer.hpp>
 #include <core/BasicTypes.hpp>
 #include <games/tictactoe/GameState.hpp>
@@ -22,10 +20,8 @@ class PerfectPlayerGenerator : public core::AbstractPlayerGenerator<tictactoe::G
   Player* generate(core::game_thread_id_t) override { return new PerfectPlayer(params_); }
   void print_help(std::ostream& s) override { params_.make_options_description().print(s); }
   void parse_args(const std::vector<std::string>& args) {
-    namespace po = boost::program_options;
-    po::variables_map vm;
-    po::store(po::command_line_parser(args).options(params_.make_options_description()).run(), vm);
-    po::notify(vm);
+    namespace po2 = boost_util::program_options;
+    po2::parse_args(params_.make_options_description(), args);
   }
 
  private:

--- a/cpp/mcts/ManagerParams.hpp
+++ b/cpp/mcts/ManagerParams.hpp
@@ -6,6 +6,7 @@
 #include <boost/filesystem.hpp>
 
 #include <mcts/Constants.hpp>
+#include <mcts/NNEvaluationServiceParams.hpp>
 #include <util/CppUtil.hpp>
 
 namespace mcts {
@@ -15,7 +16,7 @@ namespace mcts {
  *
  * By contrast, SearchParams pertains to each individual search() call.
  */
-struct ManagerParams {
+struct ManagerParams : public NNEvaluationServiceParams {
   ManagerParams(mcts::Mode);
 
   auto make_options_description();
@@ -29,14 +30,9 @@ struct ManagerParams {
   boost::filesystem::path profiling_dir() const { return {}; }
 #endif  // PROFILE_MCTS
 
-  std::string model_filename;
-  std::string cuda_device = "cuda:0";
   int num_search_threads = 8;
-  int batch_size_limit = 216;
   bool enable_pondering = false;  // pondering = think during opponent's turn
   int pondering_tree_size_limit = 4096;
-  int64_t nn_eval_timeout_ns = util::us_to_ns(250);
-  size_t cache_size = 1048576;
 
   std::string root_softmax_temperature_str;
   float cPUCT = 1.1;

--- a/cpp/mcts/NNEvaluationService.hpp
+++ b/cpp/mcts/NNEvaluationService.hpp
@@ -161,6 +161,7 @@ class NNEvaluationService {
 
   void batch_evaluate();
   void loop();
+  void weight_refresh_loop();
 
   Response check_cache(const Request&, const cache_key_t& cache_key);
   void wait_until_batch_reservable(const Request&, std::unique_lock<std::mutex>& metadata_lock);
@@ -172,6 +173,7 @@ class NNEvaluationService {
                              std::unique_lock<std::mutex>& metadata_lock);
   void wait_until_all_read(const Request&, std::unique_lock<std::mutex>& metadata_lock);
 
+  void reload_weights_if_needed();
   void wait_until_batch_ready();
   void wait_for_first_reservation();
   void wait_for_last_reservation();
@@ -249,6 +251,10 @@ class NNEvaluationService {
   batch_metadata_t batch_metadata_;
 
   int num_connections_ = 0;
+
+  std::thread* weight_refresh_thread_ = nullptr;
+  std::time_t model_last_modified_;
+  bool weight_refresh_needed_ = false;
 
   std::atomic<int> cache_hits_ = 0;
   std::atomic<int> cache_misses_ = 0;

--- a/cpp/mcts/NNEvaluationServiceParams.hpp
+++ b/cpp/mcts/NNEvaluationServiceParams.hpp
@@ -22,6 +22,11 @@ struct NNEvaluationServiceParams {
   int batch_size_limit = 216;
   int64_t nn_eval_timeout_ns = util::us_to_ns(250);
   size_t cache_size = 1048576;
+
+  /*
+   * If true, the NNEvaluationService will periodically refresh its weights from disk.
+   */
+  bool refresh_weights = false;
 };
 
 }  // namespace mcts

--- a/cpp/mcts/NNEvaluationServiceParams.hpp
+++ b/cpp/mcts/NNEvaluationServiceParams.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <boost/filesystem.hpp>
+
+#include <mcts/Constants.hpp>
+#include <util/CppUtil.hpp>
+
+namespace mcts {
+
+/*
+ * Controls behavior of an NNEvaluationService.
+ */
+struct NNEvaluationServiceParams {
+  auto make_options_description();
+  bool operator==(const NNEvaluationServiceParams& other) const = default;
+
+  std::string model_filename;
+  std::string cuda_device = "cuda:0";
+  int batch_size_limit = 216;
+  int64_t nn_eval_timeout_ns = util::us_to_ns(250);
+  size_t cache_size = 1048576;
+};
+
+}  // namespace mcts
+
+#include <mcts/inl/NNEvaluationServiceParams.inl>

--- a/cpp/mcts/SearchThread.hpp
+++ b/cpp/mcts/SearchThread.hpp
@@ -53,6 +53,7 @@ class SearchThread {
 
   int thread_id() const { return thread_id_; }
 
+  void set_profiling_dir(const boost::filesystem::path& profiling_dir);
   void join();
   void kill();
   void launch(const SearchParams* search_params, std::function<void()> f);

--- a/cpp/mcts/inl/Manager.inl
+++ b/cpp/mcts/inl/Manager.inl
@@ -33,6 +33,9 @@ inline Manager<GameState, Tensorizor>::Manager(const ManagerParams& params)
 
   if (!params.model_filename.empty()) {
     nn_eval_service_ = NNEvaluationService::create(params);
+    if (mcts::kEnableProfiling) {
+      nn_eval_service_->set_profiling_dir(params.profiling_dir());
+    }
   }
   if (num_search_threads() < 1) {
     throw util::Exception("num_search_threads must be positive (%d)", num_search_threads());
@@ -41,7 +44,11 @@ inline Manager<GameState, Tensorizor>::Manager(const ManagerParams& params)
     throw util::Exception("pondering mode does not work with only 1 search thread");
   }
   for (int i = 0; i < num_search_threads(); ++i) {
-    search_threads_.push_back(new SearchThread(&shared_data_, nn_eval_service_, &params_, i));
+    auto thread = new SearchThread(&shared_data_, nn_eval_service_, &params_, i);
+    if (mcts::kEnableProfiling) {
+      thread->set_profiling_dir(params.profiling_dir());
+    }
+    search_threads_.push_back(thread);
   }
 }
 

--- a/cpp/mcts/inl/ManagerParams.inl
+++ b/cpp/mcts/inl/ManagerParams.inl
@@ -34,28 +34,16 @@ inline auto ManagerParams::make_options_description() {
 
   po2::options_description desc("Manager options");
 
-  return desc
-      .template add_option<"model-filename", 'm'>(
-          po::value<std::string>(&model_filename),
-          "model filename. If not specified, a uniform model is implicitly used")
-      .template add_option<"cuda-device">(
-          po::value<std::string>(&cuda_device)->default_value(cuda_device), "cuda device")
+  auto out = desc
       .template add_option<"num-search-threads", 'n'>(
           po::value<int>(&num_search_threads)->default_value(num_search_threads),
           "num search threads")
-      .template add_option<"batch-size-limit", 'b'>(
-          po::value<int>(&batch_size_limit)->default_value(batch_size_limit), "batch size limit")
       .template add_bool_switches<"enable-pondering", "disable-pondering">(
           &enable_pondering, "enable pondering (search during opponent's turn)",
           "disable pondering (search during opponent's turn)")
       .template add_option<"pondering-tree-size-limit">(
           po::value<int>(&pondering_tree_size_limit)->default_value(pondering_tree_size_limit),
           "max tree size to grow to when pondering (only respected in --enable-pondering mode)")
-      .template add_option<"nn-eval-timeout-ns">(
-          po::value<int64_t>(&nn_eval_timeout_ns)->default_value(nn_eval_timeout_ns),
-          "nn eval thread timeout in ns")
-      .template add_option<"cache-size">(po::value<size_t>(&cache_size)->default_value(cache_size),
-                                         "nn eval thread cache size")
       .template add_option<"root-softmax-temp">(
           po::value<std::string>(&root_softmax_temperature_str)
               ->default_value(root_softmax_temperature_str),
@@ -75,6 +63,8 @@ inline auto ManagerParams::make_options_description() {
           "directory in which to dump mcts profiling stats")
 #endif  // PROFILE_MCTS
       ;
+
+  return out.add(NNEvaluationServiceParams::make_options_description());
 }
 
 }  // namespace mcts

--- a/cpp/mcts/inl/ManagerParams.inl
+++ b/cpp/mcts/inl/ManagerParams.inl
@@ -38,7 +38,7 @@ inline auto ManagerParams::make_options_description() {
       .template add_option<"num-search-threads", 'n'>(
           po::value<int>(&num_search_threads)->default_value(num_search_threads),
           "num search threads")
-      .template add_bool_switches<"enable-pondering", "disable-pondering">(
+      .template add_flag<"enable-pondering", "disable-pondering">(
           &enable_pondering, "enable pondering (search during opponent's turn)",
           "disable pondering (search during opponent's turn)")
       .template add_option<"pondering-tree-size-limit">(
@@ -53,9 +53,9 @@ inline auto ManagerParams::make_options_description() {
                                                   "dirichlet mult")
       .template add_option<"dirichlet-alpha-factor">(
           po2::float_value("%.2f", &dirichlet_alpha_factor), "dirichlet alpha factor")
-      .template add_bool_switches<"forced-playouts", "no-forced-playouts">(
+      .template add_flag<"forced-playouts", "no-forced-playouts">(
           &forced_playouts, "enable forced playouts", "disable forced playouts")
-      .template add_bool_switches<"enable-first-play-urgency", "disable-first-play-urgency">(
+      .template add_flag<"enable-first-play-urgency", "disable-first-play-urgency">(
           &enable_first_play_urgency, "enable first play urgency", "disable first play urgency")
 #ifdef PROFILE_MCTS
       .template add_option<"profiling-dir">(

--- a/cpp/mcts/inl/NNEvaluationServiceParams.inl
+++ b/cpp/mcts/inl/NNEvaluationServiceParams.inl
@@ -1,0 +1,34 @@
+#include <mcts/NNEvaluationServiceParams.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <util/BoostUtil.hpp>
+#include <util/Config.hpp>
+#include <util/Exception.hpp>
+#include <util/RepoUtil.hpp>
+
+namespace mcts {
+
+inline auto NNEvaluationServiceParams::make_options_description() {
+  namespace po = boost::program_options;
+  namespace po2 = boost_util::program_options;
+
+  po2::options_description desc("Neural net evaluation service options");
+
+  return desc
+      .template add_option<"model-filename", 'm'>(
+          po::value<std::string>(&model_filename),
+          "model filename. If not specified, a uniform model is implicitly used")
+      .template add_option<"cuda-device">(
+          po::value<std::string>(&cuda_device)->default_value(cuda_device), "cuda device")
+      .template add_option<"batch-size-limit", 'b'>(
+          po::value<int>(&batch_size_limit)->default_value(batch_size_limit), "batch size limit")
+      .template add_option<"nn-eval-timeout-ns">(
+          po::value<int64_t>(&nn_eval_timeout_ns)->default_value(nn_eval_timeout_ns),
+          "nn eval thread timeout in ns")
+      .template add_option<"cache-size">(po::value<size_t>(&cache_size)->default_value(cache_size),
+                                         "nn eval thread cache size")
+      ;
+}
+
+}  // namespace mcts

--- a/cpp/mcts/inl/NNEvaluationServiceParams.inl
+++ b/cpp/mcts/inl/NNEvaluationServiceParams.inl
@@ -28,7 +28,9 @@ inline auto NNEvaluationServiceParams::make_options_description() {
           "nn eval thread timeout in ns")
       .template add_option<"cache-size">(po::value<size_t>(&cache_size)->default_value(cache_size),
                                          "nn eval thread cache size")
-      ;
+      .template add_flag<"refresh-weights", "do-not-refresh-weights">(
+          &refresh_weights, "periodically refresh weights from disk",
+          "do not periodically refresh weights from disk");
 }
 
 }  // namespace mcts

--- a/cpp/mcts/inl/SearchThread.inl
+++ b/cpp/mcts/inl/SearchThread.inl
@@ -19,22 +19,24 @@ inline SearchThread<GameState, Tensorizor>::SearchThread(SharedData* shared_data
     : shared_data_(shared_data),
       nn_eval_service_(nn_eval_service),
       manager_params_(manager_params),
-      thread_id_(thread_id) {
-  if (kEnableProfiling) {
-    auto dir = manager_params->profiling_dir();
-    int manager_id = shared_data->manager_id;
-    auto profiling_file_path = dir / util::create_string("search%d-%d.txt", manager_id, thread_id);
-    profiler_.initialize_file(profiling_file_path);
-    profiler_.set_name(util::create_string("s-%d-%-2d", manager_id, thread_id));
-    profiler_.skip_next_n_dumps(5);
-  }
-}
+      thread_id_(thread_id) {}
 
 template <core::GameStateConcept GameState, core::TensorizorConcept<GameState> Tensorizor>
 inline SearchThread<GameState, Tensorizor>::~SearchThread() {
   kill();
   profiler_.dump(1);
   profiler_.close_file();
+}
+
+template <core::GameStateConcept GameState, core::TensorizorConcept<GameState> Tensorizor>
+inline void SearchThread<GameState, Tensorizor>::set_profiling_dir(
+    const boost::filesystem::path& profiling_dir) {
+  auto dir = profiling_dir;
+  int manager_id = shared_data_->manager_id;
+  auto profiling_file_path = dir / util::create_string("search%d-%d.txt", manager_id, thread_id_);
+  profiler_.initialize_file(profiling_file_path);
+  profiler_.set_name(util::create_string("s-%d-%-2d", manager_id, thread_id_));
+  profiler_.skip_next_n_dumps(5);
 }
 
 template <core::GameStateConcept GameState, core::TensorizorConcept<GameState> Tensorizor>

--- a/cpp/util/BoostUtil.hpp
+++ b/cpp/util/BoostUtil.hpp
@@ -111,7 +111,12 @@ class options_description {
   template <typename StrSeq2, util::IntSequenceConcept CharSeq2>
   auto add(const options_description<StrSeq2, CharSeq2>& desc);
 
-  void print(std::ostream& s);
+  void print(std::ostream& s) const;
+
+  friend std::ostream& operator<<(std::ostream& s, const options_description& desc) {
+    desc.print(s);
+    return s;
+  }
 
   const base_t& get() const { return *full_base_; }
   base_t& get() { return *full_base_; }
@@ -125,8 +130,8 @@ class options_description {
   template <typename, util::IntSequenceConcept>
   friend class boost_util::program_options::options_description;
 
-  base_t* full_base_;     // includes hidden options
-  base_t* base_;          // excludes hidden options
+  base_t* full_base_;    // includes hidden options
+  base_t* base_;         // excludes hidden options
   std::string tmp_str_;  // hack for convenience in augment() usage
 };
 

--- a/cpp/util/BoostUtil.hpp
+++ b/cpp/util/BoostUtil.hpp
@@ -26,10 +26,6 @@ std::string pop_option_value(std::vector<std::string>& args, const std::string& 
 
 namespace program_options {
 
-struct Settings {
-  static bool help_full;
-};
-
 /*
  * pos::value<float>(...)->default_value(...) sucks because it prints the default value with
  * undesirable precision. The official solution is to pass a second string argument to
@@ -48,6 +44,10 @@ inline auto float_value(const char* fmt, float* dest, float default_value) {
 }
 
 inline auto float_value(const char* fmt, float* dest) { return float_value(fmt, dest, *dest); }
+
+struct Settings {
+  static bool help_full;
+};
 
 /*
  * This class is a thin wrapper around boost::program_options::options_description. It aims to
@@ -73,136 +73,54 @@ inline auto float_value(const char* fmt, float* dest) { return float_value(fmt, 
  *     .add_option<"bar">(...)
  *     ;
  */
-template <typename StringLiteralSequence_ = util::StringLiteralSequence<>,
+template <typename StrSeq_ = util::StringLiteralSequence<>,
           util::IntSequenceConcept CharSeq_ = std::integer_sequence<int>>
 class options_description {
  public:
-  using StringLiteralSequence = StringLiteralSequence_;
+  using StrSeq = StrSeq_;
   using CharSeq = CharSeq_;
 
   using base_t = boost::program_options::options_description;
 
-  options_description(base_t* full_base, base_t* base) : full_base_(full_base), base_(base) {}
-
   options_description(const char* name) : full_base_(new base_t(name)), base_(new base_t(name)) {}
+  ~options_description();
 
-  // template <typename... Ts>
-  // options_description(Ts&&... ts)
-  //     : full_base_(new base_t(std::forward<Ts>(ts)...)),
-  //       base_(new base_t(std::forward<Ts>(ts)...)) {}
-
-  ~options_description() {
-    // This is bad but we deliberately leak the base_t objects here. Deleting them leads to a
-    // segfault due to how boost uses these objects. There is probably a workaround but I could not
-    // figure it out.
-  }
-
+  /*
+   * Similar to boost::program_options::options_description::add_options()(...), except that the
+   * option name(s) is passed as a template argument, rather than as a function argument. This
+   * allow for compile-time checking of name clashes.
+   */
   template <util::StringLiteral StrLit, char Char = ' ', typename... Ts>
-  auto add_option(Ts&&... ts) {
-    auto out = augment<StrLit, Char>();
-    std::string full_name = out.tmp_str_;
-
-    out.full_base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
-    out.base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
-    return out;
-  }
+  auto add_option(Ts&&... ts);
 
   /*
    * Adds both --foo and --no-foo options. One of the two will be suppressed from the --help output,
-   * depending on the value of *flag. This can be useful for boolean flags where you anticipate that
-   * you might want to change the default value, either directly in the code or via some sort of
-   * runtime switch.
+   * depending on the value of *flag. This allows you to brainlessly add both options without
+   * having to worry about what the default value is.
+   *
+   * Using --help-full instead of --help/-h will show both options.
    *
    * See: https://stackoverflow.com/a/33172979/543913
    */
   template <util::StringLiteral TrueStrLit, util::StringLiteral FalseStrLit>
-  auto add_flag(bool* flag, const char* true_help, const char* false_help) {
-    auto out = augment<TrueStrLit>().template augment<FalseStrLit>();
+  auto add_flag(bool* flag, const char* true_help, const char* false_help);
 
-    std::string full_true_help = true_help;
-    std::string full_false_help = false_help;
+  /*
+   * Adds all options from desc to this.
+   */
+  template <typename StrSeq2, util::IntSequenceConcept CharSeq2>
+  auto add(const options_description<StrSeq2, CharSeq2>& desc);
 
-    if (*flag) {
-      full_true_help += " (no-op)";
-    } else {
-      full_false_help += " (no-op)";
-    }
-
-    const char* true_name = TrueStrLit.value;
-    const char* false_name = FalseStrLit.value;
-
-    namespace po = boost::program_options;
-
-    out.full_base_->add_options()
-    (true_name, po::value(flag)->implicit_value(true)->zero_tokens(), full_true_help.c_str())
-    (false_name, po::value(flag)->implicit_value(false)->zero_tokens(), full_false_help.c_str());
-
-    if (*flag) {
-      out.base_->add_options()(false_name, po::value(flag)->implicit_value(false)->zero_tokens(),
-                              full_false_help.c_str());
-    } else {
-      out.base_->add_options()(true_name, po::value(flag)->implicit_value(true)->zero_tokens(),
-                              full_true_help.c_str());
-    }
-
-    return out;
-  }
-
-  template <typename StringLiteralSequence2, util::IntSequenceConcept CharSeq2>
-  auto add(const options_description<StringLiteralSequence2, CharSeq2>& desc) {
-    static_assert(util::no_overlap_v<StringLiteralSequence, StringLiteralSequence2>,
-                  "Options name clash!");
-    static_assert(util::no_overlap_v<CharSeq, CharSeq2>, "Options abbreviation clash!");
-
-    using StringLiteralSequence3 =
-        util::concat_string_literal_sequence_t<StringLiteralSequence, StringLiteralSequence2>;
-    using CharSeq3 = util::concat_int_sequence_t<CharSeq, CharSeq2>;
-    using OutT = options_description<StringLiteralSequence3, CharSeq3>;
-
-    full_base_->add(*desc.full_base_);
-    base_->add(*desc.base_);
-
-    OutT out(full_base_, base_);
-    return out;
-  }
-
-  void print(std::ostream& s) {
-    if (Settings::help_full) {
-      full_base_->print(s);
-    } else {
-      base_->print(s);
-    }
-  }
+  void print(std::ostream& s);
 
   const base_t& get() const { return *full_base_; }
   base_t& get() { return *full_base_; }
 
  private:
-  template <util::StringLiteral StrLit, char Char=' '>
-  auto augment() const {
-    static_assert(!util::string_literal_sequence_contains_v<StringLiteralSequence, StrLit>,
-                  "Options name clash!");
-    constexpr bool UsingAbbrev = Char != ' ';
-    static_assert(!UsingAbbrev || !util::int_sequence_contains_v<CharSeq, int(Char)>,
-                  "Options abbreviation clash!");
+  options_description(base_t* full_base, base_t* base) : full_base_(full_base), base_(base) {}
 
-    using StringLiteralSequence2 =
-        util::concat_string_literal_sequence_t<StringLiteralSequence,
-                                               util::StringLiteralSequence<StrLit>>;
-    using CharSeq2 = std::conditional_t<
-        UsingAbbrev, util::concat_int_sequence_t<CharSeq, util::int_sequence<int(Char)>>, CharSeq>;
-    using OutT = options_description<StringLiteralSequence2, CharSeq2>;
-
-    OutT out(full_base_, base_);
-
-    std::string full_name(StrLit.value);
-    if (UsingAbbrev) {
-      full_name = util::create_string("%s,%c", full_name.c_str(), Char);
-    }
-    out.tmp_str_ = full_name;
-
-    return out;
-  }
+  template <util::StringLiteral StrLit, char Char = ' '>
+  auto augment() const;
 
   template <typename, util::IntSequenceConcept>
   friend class boost_util::program_options::options_description;
@@ -212,29 +130,14 @@ class options_description {
   std::string tmp_str_;  // hack for convenience in augment() usage
 };
 
-template<typename T>
-struct _Wrap {
-  const T& operator()(const T& t) const { return t; }
-};
-
-template <typename S, util::IntSequenceConcept C>
-struct _Wrap<options_description<S, C>> {
-  const auto& operator()(const options_description<S, C>& t) const {
-    return t.get();
-  }
-};
-
-template<typename T>
-const auto& wrap(const T& t) { return _Wrap<T>()(t); }
-
+/*
+ * Constructs a boost::program_options::command_line_parser out of ts, which is expected to be
+ * a collection of strings from the command line. Uses this to store to the passed-in desc, which
+ * should be a {boost, boost_util}::program_options::options_description. Returns the parsed
+ * variables_map.
+ */
 template <typename T, typename... Ts>
-boost::program_options::variables_map parse_args(const T& desc, Ts&&... ts) {
-  namespace po = boost::program_options;
-  po::variables_map vm;
-  po::store(po::command_line_parser(std::forward<Ts>(ts)...).options(wrap(desc)).run(), vm);
-  po::notify(vm);
-  return vm;
-}
+boost::program_options::variables_map parse_args(const T& desc, Ts&&... ts);
 
 }  // namespace program_options
 

--- a/cpp/util/BoostUtil.hpp
+++ b/cpp/util/BoostUtil.hpp
@@ -116,7 +116,7 @@ class options_description {
    * See: https://stackoverflow.com/a/33172979/543913
    */
   template <util::StringLiteral TrueStrLit, util::StringLiteral FalseStrLit>
-  auto add_bool_switches(bool* flag, const char* true_help, const char* false_help) {
+  auto add_flag(bool* flag, const char* true_help, const char* false_help) {
     auto out = augment<TrueStrLit>().template augment<FalseStrLit>();
 
     std::string full_true_help = true_help;

--- a/cpp/util/BoostUtil.hpp
+++ b/cpp/util/BoostUtil.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <boost/program_options.hpp>
@@ -24,6 +25,10 @@ std::string get_option_value(const std::vector<std::string>& args, const std::st
 std::string pop_option_value(std::vector<std::string>& args, const std::string& option_name);
 
 namespace program_options {
+
+struct Settings {
+  static bool help_full;
+};
 
 /*
  * pos::value<float>(...)->default_value(...) sucks because it prints the default value with
@@ -70,58 +75,77 @@ inline auto float_value(const char* fmt, float* dest) { return float_value(fmt, 
  */
 template <typename StringLiteralSequence_ = util::StringLiteralSequence<>,
           util::IntSequenceConcept CharSeq_ = std::integer_sequence<int>>
-class options_description : public boost::program_options::options_description {
+class options_description {
  public:
   using StringLiteralSequence = StringLiteralSequence_;
   using CharSeq = CharSeq_;
 
   using base_t = boost::program_options::options_description;
 
-  template <typename... Ts>
-  options_description(Ts&&... ts) : base_t(std::forward<Ts>(ts)...) {}
+  options_description(base_t* full_base, base_t* base) : full_base_(full_base), base_(base) {}
+
+  options_description(const char* name) : full_base_(new base_t(name)), base_(new base_t(name)) {}
+
+  // template <typename... Ts>
+  // options_description(Ts&&... ts)
+  //     : full_base_(new base_t(std::forward<Ts>(ts)...)),
+  //       base_(new base_t(std::forward<Ts>(ts)...)) {}
+
+  ~options_description() {
+    // This is bad but we deliberately leak the base_t objects here. Deleting them leads to a
+    // segfault due to how boost uses these objects. There is probably a workaround but I could not
+    // figure it out.
+  }
 
   template <util::StringLiteral StrLit, char Char = ' ', typename... Ts>
   auto add_option(Ts&&... ts) {
-    static_assert(!util::string_literal_sequence_contains_v<StringLiteralSequence, StrLit>,
-                  "Options name clash!");
-    constexpr bool UsingAbbrev = Char != ' ';
-    static_assert(!UsingAbbrev || !util::int_sequence_contains_v<CharSeq, int(Char)>,
-                  "Options abbreviation clash!");
+    auto out = augment<StrLit, Char>();
+    std::string full_name = out.tmp_str_;
 
-    using StringLiteralSequence2 =
-        util::concat_string_literal_sequence_t<StringLiteralSequence,
-                                               util::StringLiteralSequence<StrLit>>;
-    using CharSeq2 = std::conditional_t<
-        UsingAbbrev, util::concat_int_sequence_t<CharSeq, util::int_sequence<int(Char)>>, CharSeq>;
-    using OutT = options_description<StringLiteralSequence2, CharSeq2>;
-
-    OutT out(*this);
-    std::string full_name(StrLit.value);
-    if (UsingAbbrev) {
-      full_name = util::create_string("%s,%c", full_name.c_str(), Char);
-    }
-
-    out.add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
+    out.full_base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
+    out.base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
     return out;
   }
 
   /*
-   * Adds both --foo and --no-foo options.
+   * Adds both --foo and --no-foo options. One of the two will be suppressed from the --help output,
+   * depending on the value of *flag. This can be useful for boolean flags where you anticipate that
+   * you might want to change the default value, either directly in the code or via some sort of
+   * runtime switch.
    *
    * See: https://stackoverflow.com/a/33172979/543913
    */
   template <util::StringLiteral TrueStrLit, util::StringLiteral FalseStrLit>
   auto add_bool_switches(bool* flag, const char* true_help, const char* false_help) {
+    auto out = augment<TrueStrLit>().template augment<FalseStrLit>();
+
+    std::string full_true_help = true_help;
+    std::string full_false_help = false_help;
+
+    if (*flag) {
+      full_true_help += " (no-op)";
+    } else {
+      full_false_help += " (no-op)";
+    }
+
+    const char* true_name = TrueStrLit.value;
+    const char* false_name = FalseStrLit.value;
+
     namespace po = boost::program_options;
 
-    std::string full_true_help = (*flag) ? "no-op" : true_help;
-    std::string full_false_help = (*flag) ? false_help : "no-op";
+    out.full_base_->add_options()
+    (true_name, po::value(flag)->implicit_value(true)->zero_tokens(), full_true_help.c_str())
+    (false_name, po::value(flag)->implicit_value(false)->zero_tokens(), full_false_help.c_str());
 
-    return (*this)
-        .template add_option<TrueStrLit>(po::value(flag)->implicit_value(true)->zero_tokens(),
-                                         full_true_help.c_str())
-        .template add_option<FalseStrLit>(po::value(flag)->implicit_value(false)->zero_tokens(),
-                                          full_false_help.c_str());
+    if (*flag) {
+      out.base_->add_options()(false_name, po::value(flag)->implicit_value(false)->zero_tokens(),
+                              full_false_help.c_str());
+    } else {
+      out.base_->add_options()(true_name, po::value(flag)->implicit_value(true)->zero_tokens(),
+                              full_true_help.c_str());
+    }
+
+    return out;
   }
 
   template <typename StringLiteralSequence2, util::IntSequenceConcept CharSeq2>
@@ -135,17 +159,82 @@ class options_description : public boost::program_options::options_description {
     using CharSeq3 = util::concat_int_sequence_t<CharSeq, CharSeq2>;
     using OutT = options_description<StringLiteralSequence3, CharSeq3>;
 
-    OutT out(*this);
-    out.add_wrapper(desc);
+    full_base_->add(*desc.full_base_);
+    base_->add(*desc.base_);
+
+    OutT out(full_base_, base_);
     return out;
   }
 
+  void print(std::ostream& s) {
+    if (Settings::help_full) {
+      full_base_->print(s);
+    } else {
+      base_->print(s);
+    }
+  }
+
+  const base_t& get() const { return *full_base_; }
+  base_t& get() { return *full_base_; }
+
  private:
-  void add_wrapper(const boost::program_options::options_description& desc) { base_t::add(desc); }
+  template <util::StringLiteral StrLit, char Char=' '>
+  auto augment() const {
+    static_assert(!util::string_literal_sequence_contains_v<StringLiteralSequence, StrLit>,
+                  "Options name clash!");
+    constexpr bool UsingAbbrev = Char != ' ';
+    static_assert(!UsingAbbrev || !util::int_sequence_contains_v<CharSeq, int(Char)>,
+                  "Options abbreviation clash!");
+
+    using StringLiteralSequence2 =
+        util::concat_string_literal_sequence_t<StringLiteralSequence,
+                                               util::StringLiteralSequence<StrLit>>;
+    using CharSeq2 = std::conditional_t<
+        UsingAbbrev, util::concat_int_sequence_t<CharSeq, util::int_sequence<int(Char)>>, CharSeq>;
+    using OutT = options_description<StringLiteralSequence2, CharSeq2>;
+
+    OutT out(full_base_, base_);
+
+    std::string full_name(StrLit.value);
+    if (UsingAbbrev) {
+      full_name = util::create_string("%s,%c", full_name.c_str(), Char);
+    }
+    out.tmp_str_ = full_name;
+
+    return out;
+  }
 
   template <typename, util::IntSequenceConcept>
   friend class boost_util::program_options::options_description;
+
+  base_t* full_base_;     // includes hidden options
+  base_t* base_;          // excludes hidden options
+  std::string tmp_str_;  // hack for convenience in augment() usage
 };
+
+template<typename T>
+struct _Wrap {
+  const T& operator()(const T& t) const { return t; }
+};
+
+template <typename S, util::IntSequenceConcept C>
+struct _Wrap<options_description<S, C>> {
+  const auto& operator()(const options_description<S, C>& t) const {
+    return t.get();
+  }
+};
+
+template<typename T>
+const auto& wrap(const T& t) { return _Wrap<T>()(t); }
+
+template <typename T, typename... Ts>
+boost::program_options::variables_map parse_args(const T& desc, Ts&&... ts) {
+  namespace po = boost::program_options;
+  po::variables_map vm;
+  po::store(po::command_line_parser(std::forward<Ts>(ts)...).options(wrap(desc)).run(), vm);
+  po::notify(vm);
+  return vm;
+}
 
 }  // namespace program_options
 

--- a/cpp/util/StaticVars.cpp
+++ b/cpp/util/StaticVars.cpp
@@ -1,3 +1,4 @@
+#include <util/BoostUtil.hpp>
 #include <util/Config.hpp>
 #include <util/KeyValueDumper.hpp>
 #include <util/Random.hpp>
@@ -5,6 +6,14 @@
 #include <util/ScreenUtil.hpp>
 #include <util/ThreadSafePrinter.hpp>
 #include <util/SocketUtil.hpp>
+
+namespace boost_util {
+namespace program_options {
+
+bool Settings::help_full = false;
+
+}  // namespace program_options
+}  // namespace boost_util
 
 namespace util {
 

--- a/cpp/util/StringUtil.hpp
+++ b/cpp/util/StringUtil.hpp
@@ -39,6 +39,8 @@ std::vector<std::string> split(const std::string& s);
 template <int N = 1024>
 inline std::string create_string(char const* fmt, ...);
 
+bool ends_with(const std::string& value, const std::string& ending);
+
 }  // namespace util
 
 #include <util/inl/StringUtil.inl>

--- a/cpp/util/inl/BoostUtil.inl
+++ b/cpp/util/inl/BoostUtil.inl
@@ -52,4 +52,140 @@ inline std::string pop_option_value(std::vector<std::string>& args,
   return "";
 }
 
+namespace program_options {
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+options_description<StrSeq, CharSeq>::~options_description() {
+  // This is bad but we deliberately leak the base_t objects here. Deleting them leads to a
+  // segfault due to how boost uses these objects. There is probably a workaround but I could not
+  // figure it out.
+}
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+template <util::StringLiteral StrLit, char Char, typename... Ts>
+auto options_description<StrSeq, CharSeq>::add_option(Ts&&... ts) {
+  auto out = augment<StrLit, Char>();
+  std::string full_name = out.tmp_str_;
+
+  out.full_base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
+  out.base_->add_options()(full_name.c_str(), std::forward<Ts>(ts)...);
+  return out;
+}
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+template <util::StringLiteral TrueStrLit, util::StringLiteral FalseStrLit>
+auto options_description<StrSeq, CharSeq>::add_flag(bool* flag, const char* true_help,
+                                                    const char* false_help) {
+  auto out = augment<TrueStrLit>().template augment<FalseStrLit>();
+
+  std::string full_true_help = true_help;
+  std::string full_false_help = false_help;
+
+  if (*flag) {
+    full_true_help += " (no-op)";
+  } else {
+    full_false_help += " (no-op)";
+  }
+
+  const char* true_name = TrueStrLit.value;
+  const char* false_name = FalseStrLit.value;
+
+  namespace po = boost::program_options;
+
+  out.full_base_->add_options()
+  (true_name, po::value(flag)->implicit_value(true)->zero_tokens(), full_true_help.c_str())
+  (false_name, po::value(flag)->implicit_value(false)->zero_tokens(), full_false_help.c_str());
+
+  if (*flag) {
+    out.base_->add_options()(false_name, po::value(flag)->implicit_value(false)->zero_tokens(),
+                            full_false_help.c_str());
+  } else {
+    out.base_->add_options()(true_name, po::value(flag)->implicit_value(true)->zero_tokens(),
+                            full_true_help.c_str());
+  }
+
+  return out;
+}
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+template <typename StrSeq2, util::IntSequenceConcept CharSeq2>
+auto options_description<StrSeq, CharSeq>::add(const options_description<StrSeq2, CharSeq2>& desc) {
+  static_assert(util::no_overlap_v<StrSeq, StrSeq2>, "Options name clash!");
+  static_assert(util::no_overlap_v<CharSeq, CharSeq2>, "Options abbreviation clash!");
+
+  using StrSeq3 = util::concat_string_literal_sequence_t<StrSeq, StrSeq2>;
+  using CharSeq3 = util::concat_int_sequence_t<CharSeq, CharSeq2>;
+  using OutT = options_description<StrSeq3, CharSeq3>;
+
+  full_base_->add(*desc.full_base_);
+  base_->add(*desc.base_);
+
+  OutT out(full_base_, base_);
+  return out;
+}
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+void options_description<StrSeq, CharSeq>::print(std::ostream& s) {
+  if (Settings::help_full) {
+    full_base_->print(s);
+  } else {
+    base_->print(s);
+  }
+}
+
+template <typename StrSeq, util::IntSequenceConcept CharSeq>
+template <util::StringLiteral StrLit, char Char>
+auto options_description<StrSeq, CharSeq>::augment() const {
+  static_assert(!util::string_literal_sequence_contains_v<StrSeq, StrLit>, "Options name clash!");
+  constexpr bool UsingAbbrev = Char != ' ';
+  static_assert(!UsingAbbrev || !util::int_sequence_contains_v<CharSeq, int(Char)>,
+                "Options abbreviation clash!");
+
+  using StrSeq2 =
+      util::concat_string_literal_sequence_t<StrSeq, util::StringLiteralSequence<StrLit>>;
+  using CharSeq2 = std::conditional_t<
+      UsingAbbrev, util::concat_int_sequence_t<CharSeq, util::int_sequence<int(Char)>>, CharSeq>;
+  using OutT = options_description<StrSeq2, CharSeq2>;
+
+  OutT out(full_base_, base_);
+
+  std::string full_name(StrLit.value);
+  if (UsingAbbrev) {
+    full_name = util::create_string("%s,%c", full_name.c_str(), Char);
+  }
+  out.tmp_str_ = full_name;
+
+  return out;
+}
+
+namespace detail {
+
+template <typename T>
+struct Wrap {
+  const T& operator()(const T& t) const { return t; }
+};
+
+template <typename S, util::IntSequenceConcept C>
+struct Wrap<options_description<S, C>> {
+  const auto& operator()(const options_description<S, C>& t) const { return t.get(); }
+};
+
+template <typename T>
+const auto& wrap(const T& t) {
+  return Wrap<T>()(t);
+}
+
+}  // namespace detail
+
+template <typename T, typename... Ts>
+boost::program_options::variables_map parse_args(const T& desc, Ts&&... ts) {
+  namespace po = boost::program_options;
+  po::variables_map vm;
+  po::store(po::command_line_parser(std::forward<Ts>(ts)...).options(detail::wrap(desc)).run(), vm);
+  po::notify(vm);
+  return vm;
+}
+
+}  // namespace program_options
+
 }  // namespace boost_util

--- a/cpp/util/inl/BoostUtil.inl
+++ b/cpp/util/inl/BoostUtil.inl
@@ -125,7 +125,7 @@ auto options_description<StrSeq, CharSeq>::add(const options_description<StrSeq2
 }
 
 template <typename StrSeq, util::IntSequenceConcept CharSeq>
-void options_description<StrSeq, CharSeq>::print(std::ostream& s) {
+void options_description<StrSeq, CharSeq>::print(std::ostream& s) const {
   if (Settings::help_full) {
     full_base_->print(s);
   } else {

--- a/cpp/util/inl/StringUtil.inl
+++ b/cpp/util/inl/StringUtil.inl
@@ -66,4 +66,9 @@ inline std::string create_string(char const *fmt, ...) {
   return std::string(text);
 }
 
+inline bool ends_with(const std::string& value, const std::string& ending) {
+  if (ending.size() > value.size()) return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
 }  // namespace util


### PR DESCRIPTION
`--refresh-weights` option for MCTS players, which causes the net weights to refresh if the model file's modify-timestamp to change. Currently this is unused, but with proper changes on python side we can use this for continuous self-play.

Lumped in some unrelated improvements to BoostUtil.