### PR TITLE
automatically check whether conda env is up-to-date in env_setup.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cmake-build-debug
 
 # env
 .env.sh
+.environment.yml.md5
 
 # cmake build dir
 target

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -13,3 +13,24 @@ else
         source "$ENV_VARS_SCRIPT"
     fi
 fi
+
+# Validate that md5sum of environment.yml file matches the one in .environment.yml.md5:
+MD5_MATCH=1
+if [ -e "$SCRIPT_DIR/.environment.yml.md5" ]; then
+    MD5_SUM=$(md5sum "$SCRIPT_DIR/environment.yml")
+    MD5_SUM=$(echo $MD5_SUM | cut -d ' ' -f 1)
+    EXPECTED_MD5_SUM=$(cat "$SCRIPT_DIR/.environment.yml.md5")
+    if [ "$MD5_SUM" != "$EXPECTED_MD5_SUM" ]; then
+        MD5_MATCH=0
+    fi
+else
+    MD5_MATCH=0
+fi
+
+if [ $MD5_MATCH -eq 0 ]; then
+    # Alert the user in red font:
+    echo -e "\033[0;31m"
+    echo "Your conda environment is out of date. Please run the following command:"
+    echo -e "\033[0m"
+    echo "   ./py/update_conda_env.py"
+fi

--- a/environment.yml
+++ b/environment.yml
@@ -146,6 +146,7 @@ dependencies:
   - ncurses=6.3=h27087fc_1
   - nest-asyncio=1.5.6=pyhd8ed1ab_0
   - nettle=3.8.1=hc379101_1
+  - networkx=3.3=pyhd8ed1ab_1
   - nodejs=18.10.0=h8839609_0
   - notebook=6.5.3=pyha770c72_0
   - notebook-shim=0.2.2=pyhd8ed1ab_0

--- a/py/export_conda_env.py
+++ b/py/export_conda_env.py
@@ -26,3 +26,7 @@ with open(file_path, 'w') as fp:
     fp.write('\n'.join(lines[1: -1] + [""]))
 
 print(f"File {file_name} is saved to {file_path}.")
+
+md5_hash = os.popen('md5sum environment.yml').read().split()[0]
+with open('.environment.yml.md5', 'w') as f:
+    f.write(md5_hash)

--- a/py/update_conda_env.py
+++ b/py/update_conda_env.py
@@ -14,6 +14,9 @@ if response in ('y', 'Y'):
     os.chdir(repo_root)
 
     os.system(cmd)
+
+    md5_hash = os.popen('md5sum environment.yml').read().split()[0]
+    with open('.environment.yml.md5', 'w') as f:
+        f.write(md5_hash)
 else:
     print('\nExiting without update.')
-

--- a/py/update_conda_env.py
+++ b/py/update_conda_env.py
@@ -8,6 +8,7 @@ print(cmd)
 
 print('')
 print('This may irreversibly change your conda env.')
+print('Conda packages that you installed manually may be removed.')
 response = input('Are you sure you want to continue? [y/N]: ')
 if response in ('y', 'Y'):
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -106,6 +106,10 @@ def setup_conda(env_sh_lines):
         if os.system(f'conda env create -f environment.yml -n {env_name}'):
             raise VerboseSetupException('Failed to create conda environment.')
         print(f'Conda environment {env_name} successfully created!')
+
+        md5_hash = os.popen('md5sum environment.yml').read().split()[0]
+        with open('.environment.yml.md5', 'w') as f:
+            f.write(md5_hash)
     else:
         print(f'Conda environment {env_name} already exists, skipping creation.')
     return env_name


### PR DESCRIPTION
When you get a chance, can you check this branch out and try to do a `source env_setup.sh` call? It will ask you to call `update_conda_env.py` (even though you probably don't need to).

Note that `update_conda_env.py` will delete any conda packages that you've added manually. It also takes a few minutes.

After you successfully run that, try to do `source env_setup.sh` again. The second time, you should get no complaints.